### PR TITLE
Move to expect/actual for MPFile

### DIFF
--- a/android/src/main/java/com/darkrockstudios/libraries/mpfilepicker/android/MainActivity.kt
+++ b/android/src/main/java/com/darkrockstudios/libraries/mpfilepicker/android/MainActivity.kt
@@ -30,10 +30,11 @@ class MainActivity : AppCompatActivity() {
                     }
                     Text("File Chosen: $pathChosen")
 
-
                     val fileType = listOf("jpg", "png")
-                    FilePicker(showFilePicker, fileExtensions = fileType) { path ->
-                        pathChosen = path ?: "none selected"
+                    FilePicker(showFilePicker, fileExtensions = fileType) { mpFile ->
+                        if(mpFile != null) {
+                            pathChosen = mpFile.path
+                        }
                         showFilePicker = false
                     }
 

--- a/desktopExample/src/jvmMain/kotlin/Main.kt
+++ b/desktopExample/src/jvmMain/kotlin/Main.kt
@@ -39,7 +39,7 @@ fun main() = application {
     }
 
     FilePicker(show, fileExtensions = listOf("jpg", "png")) { file ->
-        pathChosen = file?.fileNameOrPath ?: "none selected"
+        pathChosen = file?.path ?: "none selected"
         show = false
     }
 

--- a/mpfilepicker/src/androidMain/kotlin/com/darkrockstudios/libraries/mpfilepicker/AndroidFilePicker.kt
+++ b/mpfilepicker/src/androidMain/kotlin/com/darkrockstudios/libraries/mpfilepicker/AndroidFilePicker.kt
@@ -1,20 +1,30 @@
 package com.darkrockstudios.libraries.mpfilepicker
 
+import android.net.Uri
 import android.webkit.MimeTypeMap
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 
+data class AndroidFile(
+	override val path: String,
+	override val platfromFile: Uri,
+) : MPFile<Uri>
+
 @Composable
 actual fun FilePicker(
 	show: Boolean,
 	initialDirectory: String?,
 	fileExtensions: List<String>,
-	onFileSelected: (MPFile?) -> Unit
+	onFileSelected: FileSelected
 ) {
 	val launcher = rememberLauncherForActivityResult(contract = ActivityResultContracts.OpenDocument()) { result ->
-		onFileSelected(MPFile.Other(result?.toString()))
+		if(result != null) {
+			onFileSelected(AndroidFile(result.toString(), result))
+		} else {
+			onFileSelected(null)
+		}
 	}
 
 	val mimeTypeMap = MimeTypeMap.getSingleton()

--- a/mpfilepicker/src/androidMain/kotlin/com/darkrockstudios/libraries/mpfilepicker/AndroidFilePicker.kt
+++ b/mpfilepicker/src/androidMain/kotlin/com/darkrockstudios/libraries/mpfilepicker/AndroidFilePicker.kt
@@ -9,7 +9,7 @@ import androidx.compose.runtime.LaunchedEffect
 
 data class AndroidFile(
 	override val path: String,
-	override val platfromFile: Uri,
+	override val platformFile: Uri,
 ) : MPFile<Uri>
 
 @Composable

--- a/mpfilepicker/src/commonMain/kotlin/com/darkrockstudios/libraries/mpfilepicker/FilePicker.kt
+++ b/mpfilepicker/src/commonMain/kotlin/com/darkrockstudios/libraries/mpfilepicker/FilePicker.kt
@@ -5,7 +5,7 @@ import androidx.compose.runtime.Composable
 interface MPFile<out T: Any> {
     // on JS this will be a file name, on other platforms it will be a file path
     val path: String
-    val platfromFile: T
+    val platformFile: T
 }
 
 typealias FileSelected = (MPFile<Any>?) -> Unit

--- a/mpfilepicker/src/commonMain/kotlin/com/darkrockstudios/libraries/mpfilepicker/FilePicker.kt
+++ b/mpfilepicker/src/commonMain/kotlin/com/darkrockstudios/libraries/mpfilepicker/FilePicker.kt
@@ -2,12 +2,20 @@ package com.darkrockstudios.libraries.mpfilepicker
 
 import androidx.compose.runtime.Composable
 
+interface MPFile<out T: Any> {
+    // on JS this will be a file name, on other platforms it will be a file path
+    val path: String
+    val platfromFile: T
+}
+
+typealias FileSelected = (MPFile<Any>?) -> Unit
+
 @Composable
 expect fun FilePicker(
     show: Boolean,
     initialDirectory: String? = null,
     fileExtensions: List<String> = emptyList(),
-    onFileSelected: (MPFile?) -> Unit
+    onFileSelected: FileSelected
 )
 
 @Composable
@@ -16,18 +24,3 @@ expect fun DirectoryPicker(
     initialDirectory: String? = null,
     onFileSelected: (String?) -> Unit
 )
-
-sealed interface MPFile {
-
-    // on JS this will be a file name, on other platforms it will be a file path
-    val fileNameOrPath: String?
-
-    data class Web(
-        override val fileNameOrPath: String,
-        private val fileReader: suspend () -> String
-    ) : MPFile {
-        suspend fun getFileContents() = fileReader()
-    }
-
-    data class Other(override val fileNameOrPath: String?) : MPFile
-}

--- a/mpfilepicker/src/desktopMain/kotlin/com/darkrockstudios/libraries/mpfilepicker/DesktopFilePicker.kt
+++ b/mpfilepicker/src/desktopMain/kotlin/com/darkrockstudios/libraries/mpfilepicker/DesktopFilePicker.kt
@@ -10,7 +10,7 @@ import java.io.File
 
 data class JvmFile(
     override val path: String,
-    override val platfromFile: File,
+    override val platformFile: File,
 ) : MPFile<File>
 
 @Composable

--- a/mpfilepicker/src/desktopMain/kotlin/com/darkrockstudios/libraries/mpfilepicker/DesktopFilePicker.kt
+++ b/mpfilepicker/src/desktopMain/kotlin/com/darkrockstudios/libraries/mpfilepicker/DesktopFilePicker.kt
@@ -6,13 +6,19 @@ import androidx.compose.runtime.rememberCoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import java.io.File
+
+data class JvmFile(
+    override val path: String,
+    override val platfromFile: File,
+) : MPFile<File>
 
 @Composable
 actual fun FilePicker(
     show: Boolean,
     initialDirectory: String?,
     fileExtensions: List<String>,
-    onFileSelected: (MPFile?) -> Unit
+    onFileSelected: FileSelected
 ) {
     val scope = rememberCoroutineScope()
     LaunchedEffect(show) {
@@ -30,7 +36,11 @@ actual fun FilePicker(
                     fileExtensions = fileFilter
                 )
                 withContext(Dispatchers.Main) {
-                    onFileSelected(MPFile.Other(filePath))
+                    if(filePath != null) {
+                        onFileSelected(JvmFile(filePath, File(filePath)))
+                    } else {
+                        onFileSelected(null)
+                    }
                 }
             }
         }

--- a/mpfilepicker/src/jsMain/kotlin/com/darkrockstudios/libraries/mpfilepicker/JsFilePicker.kt
+++ b/mpfilepicker/src/jsMain/kotlin/com/darkrockstudios/libraries/mpfilepicker/JsFilePicker.kt
@@ -12,19 +12,24 @@ import org.w3c.files.FileReader
 import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
 
+data class WebFile(
+    override val path: String,
+    override val platfromFile: File,
+) : MPFile<File> {
+    suspend fun getFileContents() = readFileAsText(platfromFile)
+}
+
 @Composable
 actual fun FilePicker(
     show: Boolean,
     initialDirectory: String?,
-    fileExtensions: List<String>, // TODO add support for multiple filters
-    onFileSelected: (MPFile?) -> Unit
+    fileExtensions: List<String>,
+    onFileSelected: FileSelected
 ) {
     LaunchedEffect(show) {
         if(show) {
-            val file = document.selectFilesFromDisk(fileExtensions.first(), true)
-            onFileSelected(MPFile.Web(file.first().name) {
-                readFileAsText(file.first())
-            }) // TODO support multiple files
+            val file: List<File> = document.selectFilesFromDisk(fileExtensions.first(), true)
+            onFileSelected(WebFile(file.first().name, file.first())) // TODO support multiple files
         }
     }
 }
@@ -59,7 +64,7 @@ private suspend fun Document.selectFilesFromDisk(
     tempInput.remove()
 }
 
-private suspend fun readFileAsText(file: File) = suspendCoroutine {
+suspend fun readFileAsText(file: File) = suspendCoroutine {
     val reader = FileReader()
     reader.onload = { loadEvt ->
         val content = loadEvt.target.asDynamic().result as String

--- a/mpfilepicker/src/jsMain/kotlin/com/darkrockstudios/libraries/mpfilepicker/JsFilePicker.kt
+++ b/mpfilepicker/src/jsMain/kotlin/com/darkrockstudios/libraries/mpfilepicker/JsFilePicker.kt
@@ -14,9 +14,9 @@ import kotlin.coroutines.suspendCoroutine
 
 data class WebFile(
     override val path: String,
-    override val platfromFile: File,
+    override val platformFile: File,
 ) : MPFile<File> {
-    suspend fun getFileContents() = readFileAsText(platfromFile)
+    suspend fun getFileContents() = readFileAsText(platformFile)
 }
 
 @Composable

--- a/mpfilepicker/src/jsMain/kotlin/com/darkrockstudios/libraries/mpfilepicker/JsFilePicker.kt
+++ b/mpfilepicker/src/jsMain/kotlin/com/darkrockstudios/libraries/mpfilepicker/JsFilePicker.kt
@@ -41,6 +41,7 @@ actual fun DirectoryPicker(
     onFileSelected: (String?) -> Unit
 ) {
     // in a browser we can not pick directories
+    throw NotImplementedError("DirectoryPicker is not supported on the web")
 }
 
 private suspend fun Document.selectFilesFromDisk(

--- a/mpfilepicker/src/jsMain/kotlin/com/darkrockstudios/libraries/mpfilepicker/JsFilePicker.kt
+++ b/mpfilepicker/src/jsMain/kotlin/com/darkrockstudios/libraries/mpfilepicker/JsFilePicker.kt
@@ -28,7 +28,8 @@ actual fun FilePicker(
 ) {
     LaunchedEffect(show) {
         if(show) {
-            val file: List<File> = document.selectFilesFromDisk(fileExtensions.first(), true)
+            val fixedExtensions = fileExtensions.map { ".$it" }
+            val file: List<File> = document.selectFilesFromDisk(fixedExtensions.first(), true)
             onFileSelected(WebFile(file.first().name, file.first())) // TODO support multiple files
         }
     }

--- a/webExample/src/main/kotlin/main.kt
+++ b/webExample/src/main/kotlin/main.kt
@@ -1,6 +1,7 @@
 import androidx.compose.runtime.*
 import com.darkrockstudios.libraries.mpfilepicker.FilePicker
-import com.darkrockstudios.libraries.mpfilepicker.MPFile
+import com.darkrockstudios.libraries.mpfilepicker.WebFile
+import com.darkrockstudios.libraries.mpfilepicker.readFileAsText
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.web.dom.Br
 import org.jetbrains.compose.web.dom.Button
@@ -25,12 +26,13 @@ fun main() {
         Br()
         Text("File content: $fileContents")
 
-        FilePicker(show, fileExtensions = listOf(".txt", ".png")) { path ->
-            fileName = path?.fileNameOrPath ?: "none selected"
-            scope.launch {
-                fileContents = (path as MPFile.Web).getFileContents()
+        FilePicker(show, fileExtensions = listOf(".txt", ".png")) { file ->
+            if(file is WebFile) {
+                fileName = file.path ?: "none selected"
+                scope.launch {
+                    fileContents = readFileAsText(file.platfromFile)
+                }
             }
-            show = false
         }
     }
 }

--- a/webExample/src/main/kotlin/main.kt
+++ b/webExample/src/main/kotlin/main.kt
@@ -26,7 +26,7 @@ fun main() {
         Br()
         Text("File content: $fileContents")
 
-        FilePicker(show, fileExtensions = listOf(".txt", ".png")) { file ->
+        FilePicker(show, fileExtensions = listOf("txt", "md")) { file ->
             if(file is WebFile) {
                 fileName = file.path ?: "none selected"
                 scope.launch {

--- a/webExample/src/main/kotlin/main.kt
+++ b/webExample/src/main/kotlin/main.kt
@@ -30,7 +30,7 @@ fun main() {
             if(file is WebFile) {
                 fileName = file.path ?: "none selected"
                 scope.launch {
-                    fileContents = readFileAsText(file.platfromFile)
+                    fileContents = readFileAsText(file.platformFile)
                 }
             }
         }


### PR DESCRIPTION
Ok here is a tweak.

It uses expect/actual for the File class instead of a sealed class.

My thinking is in common code, like shared compose UI code or something, we get this class, and then the file read code will also live in expect/actual code.

The platform specific representations of the file can be referenced as well in their platform specific classes.

If you like this, lets pull this into ur repo, and update your PR with it.